### PR TITLE
fix selection is incorrect when items changed but items count remained

### DIFF
--- a/px-dropdown-content.html
+++ b/px-dropdown-content.html
@@ -535,7 +535,11 @@ limitations under the License.
           }
         }.bind(this));
       }
+      var shouldRenderSynchronously = newComputedItems.length === this._computedItems.length;
       this._computedItems = newComputedItems;
+      if (shouldRenderSynchronously) {
+        this.$.dropdownItems.render();
+      }
       if(this.clearSelectionsOnChange) {
         this.set('selected', null);
         this.set('selectedValues', []);

--- a/px-dropdown.html
+++ b/px-dropdown.html
@@ -173,7 +173,8 @@ Custom property | Description
         hide-selected="[[hideSelected]]"
         allow-outside-scroll="[[allowOutsideScroll]]"
         display-value-selected="{{_displayValueSelected}}"
-        disable-truncate="[[disableTruncate]]">
+        disable-truncate="[[disableTruncate]]"
+        clear-selections-on-change="[[clearSelectionsOnChange]]">
       </px-dropdown-content>
     </px-overlay-content>
   </template>


### PR DESCRIPTION
When `items` of dropdown changed, but items count was not changed, the selected item will be incorrect.

For example items were ['foo', 'bar'], 'bar' was selected, then items changed to ['bar', 'baz'], the `selected` attribute is still 'bar', but in dropdown, it shows 'baz' is selected.

The root cause is that items are rendered asynchronously, `this._updateSelection();` is invoked before the `dropdownItems` refreshed, so the selection is still on old `items`. After `dropdownItems` refreshed, the content was updated, but selection was not updated to reflect correct item.